### PR TITLE
adding feature to assign custom output filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # pigz-python
-The goal of this project is to create a pure Python implementation of the pigz project for parallelizing gzipping.
 
+The goal of this project is to create a pure Python implementation of the pigz project for parallelizing gzipping.
 
 # Usage examples
 
 pigz-python can be utilized by creating a `PigzFile` object and calling the `process_compression_target()` method.
+Note: `output` file name is optional and the default value would be existing filename.
 
 ```python
 from pigz_python import PigzFile
 
-pigz_file = PigzFile('foo.txt')
+pigz_file = PigzFile('foo.txt', 'compressed')
 pigz_file.process_compression_target()
 ```
 
@@ -18,5 +19,5 @@ Alternatively, the pigz_python module also provides a convenient helper method t
 ```python
 import pigz_python
 
-pigz_python.compress_file('foo.txt')
+pigz_python.compress_file('foo.txt', 'compressed')
 ```


### PR DESCRIPTION
This PR addresses the issue of not being able to specify the output file name when using the package. The changes add a new parameter to the function that allows the user to specify the desired output file name. The default behavior remains unchanged if the user does not specify a custom file name.

## Changes Made

- Added a new `output_name` parameter to the function
- If the `output_name` parameter is provided, the output will be saved to a file with that name. If the parameter is not provided, the default file name will be used.
- ".gz" is added if not present in the `output_name` provided by user.
- Updated the ReadMe file with appropriate example and note.


Closes https://github.com/nix7drummer88/pigz-python/issues/36